### PR TITLE
Update PyNE Feedstock to make a working lite version

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,7 +6,6 @@ if [ "$(uname)" == "Darwin" ]; then
 else
   skiprpath=""
 fi
-#export FC=gfortran
 
 # Install PyNE
 export VERBOSE=1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,3 +5,6 @@ enable_moab:
 enable_openmc:
   - noopenmc
   - openmc
+
+channel_targets:
+  - conda_forge pyne_rc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,8 @@
-{% set name = "pyne" %}
+{% set org = "pyne" %}
 {% set version = "0.7.0" %}
-{% set build = 1 %}
+{% set build = "0" %}
 {% set sha256 = "19e104a05aa56ef2e747f5e4a1c4cffefdb57a592a300823265ba72a1b55d4f3" %}
 
-# ensure moab is defined (needed for conda-smithy recipe-lint)
-{% set enable_moab = enable_moab or 'nomoab' %}
-
-# ensure openmc is defined (needed for conda-smithy recipe-lint)
-{% set enable_openmc = enable_openmc or 'noopenmc' %}
 
 
 package:
@@ -16,26 +11,12 @@ package:
 
 source:
   fn: pyne-{{ version }}-{{ sha256 }}.tar.gz
-  url: https://github.com/{{ name }}/pyne/archive/{{ version }}-rc1.tar.gz
+  url: https://github.com/{{ org }}/pyne/archive/{{ version }}-rc1.tar.gz
   sha256: {{ sha256 }}
 
 build:
   number: {{ build }}
-  {% if enable_moab == 'moab' %}
-  {% set moab_prefix = "moab" %}
-  {% else %}
-  {% set moab_prefix = "nomoab" %}
-  {% endif %}
-  
-  {% if enable_openmc == 'openmc' %}
-  {% set openmc_prefix = "openmc" %}
-  {% else %}
-  {% set openmc_prefix = "noopenmc" %}
-  {% endif %}
-  
-  string: "{{ moab_prefix }}_{{ openmc_prefix }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ build }}"
-
-  skip: True  # [win or (osx and py34) or (py27 and enable_openmc == 'openmc') ]
+  skip: True  # [win or (osx and py34)]
   detect_binary_files_with_prefix: true
 
 requirements:
@@ -51,8 +32,6 @@ requirements:
     - numpy
     - pytables
     - cython
-    - moab  # [ enable_moab == 'moab' ]
-    - openmc  # [ enable_openmc == 'openmc' ]
   run:
     - python
     - hdf5
@@ -61,8 +40,6 @@ requirements:
     - scipy
     - future
     - jinja2
-    - moab  # [ enable_moab == 'moab' ]
-    - openmc  # [ enable_openmc == 'openmc' ]
 test:
   requires:
     - nose

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
 
 about:
   home: http://pyne.io/
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_file: license.txt
   summary: "The nuclear engineering toolkit"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,3 +83,4 @@ extra:
     - gonuke
     - bam241
     - kkiesling
+    - opotowsky

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set org = "pyne" %}
 {% set version = "0.7.0" %}
-{% set build = "1" %}
+{% set build = "2" %}
 {% set sha256 = "19e104a05aa56ef2e747f5e4a1c4cffefdb57a592a300823265ba72a1b55d4f3" %}
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set org = "pyne" %}
 {% set version = "0.7.0" %}
-{% set build = "0" %}
+{% set build = "1" %}
 {% set sha256 = "19e104a05aa56ef2e747f5e4a1c4cffefdb57a592a300823265ba72a1b55d4f3" %}
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,3 @@ extra:
     - gonuke
     - bam241
     - kkiesling
-    - a-co
-    - opotowsky
-    - katyhuff
-    - pshriwise


### PR DESCRIPTION
This PR should be a working recipe for a PyNE "lite" conda package. "Lite" = not including the MOAB and DAGMC dependencies (those to come in a future PR). 

Recipe and build updates:
* removes MOAB and DAGMC specifications
* removes unnecessary packages for build/host/run so that only bare minimum are included
* upgraded to be compatible with conda build 3
* added additional maintainers for the pyne-feedstock who are active developers on PyNE

This can replace PR #36 (fixes issue #35). I believe this also fixes version incompatibilities as described in #31. 

PR Co-authors: @bam241 @opotowsky @gonuke

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* ~~[] Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
